### PR TITLE
Improve README with local serve and Sass info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,27 @@ This repository contains the static website for the Anxiety Reduction Retreat he
 
 See [index.md](index.md) for full retreat details.
 
-## Viewing or Deploying
+## Serving Locally
 
-Open `index.html` in your web browser to browse the site locally. You can also host these files with any static site provider, such as GitHub Pages, to make the site publicly accessible.
+Open `index.html` directly in a browser or start a simple web server from the repository root:
+
+```bash
+python3 -m http.server
+```
+
+Then visit `http://localhost:8000`.
+
+### Editing Sass
+
+Styles are authored in `assets/sass`. Rebuild `assets/css/main.css` after making changes with the [Sass](https://sass-lang.com/) CLI:
+
+```bash
+sass assets/sass/main.scss assets/css/main.css
+```
+
+## Deployment
+
+Commit the generated files and push to a branch configured for GitHub Pages (e.g. `main` or `gh-pages`). GitHub will serve the contents at your chosen domain.
 
 ## License and Credits
 


### PR DESCRIPTION
## Summary
- document serving the site locally
- describe how to rebuild `main.css` from Sass
- add deployment instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b97e5129883318eb90c1c8184516d